### PR TITLE
 Ensures $xml_items is always an array before it's treated as such.

### DIFF
--- a/helpers/phocacommander.php
+++ b/helpers/phocacommander.php
@@ -46,7 +46,7 @@ class PhocaCommanderHelper
 			}
 		}
 
-		$xml_items = '';
+		$xml_items = array();
 		if (count($xmlFilesInDir))
 		{
 			foreach ($xmlFilesInDir as $xmlfile)


### PR DESCRIPTION
Fixes PHP 7.1 warnings regarding “Illegal string offset” and “Cannot assign an empty string”.